### PR TITLE
Reduce unit testing frequency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,9 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -11,18 +13,10 @@ jobs:
       matrix:
         version:
           - '1'    # Latest release
-          - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
-        exclude:
-          - os: macOS-latest
-            version: 'nightly'
-          - os: windows-latest
-            version: 'nightly'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -17,7 +17,7 @@ julia> data[end,1:end] .= rand(100);  # Randomize the last dimension of each poi
 julia> hashes = map(x -> hashfn(x), eachcol(data));
 
 julia> unique(hashes)
-1-element Array{BitArray{1},1}:
+1-element Vector{BitVector}:
  [0]
 ```
 

--- a/docs/src/function_hashing.md
+++ b/docs/src/function_hashing.md
@@ -13,7 +13,7 @@ julia> μ() = 2π*rand();   # μ samples a random point from [0,2π]
 julia> hashfn = MonteCarloHash(cossim, μ, 3);
 
 julia> hashfn(x -> 5x^3 - 2x^2 - 9x + 1)
-3-element BitArray{1}:
+3-element BitVector:
  0
  1
  1
@@ -75,13 +75,13 @@ julia> μ() = 2π * rand(); # μ samples a random point from [0,2π]
 julia> hashfn = MonteCarloHash(L2, μ, 3; volume=2π);
 
 julia> hashfn(cos)
-3-element Array{Int32,1}:
+3-element Vector{Int32}:
  -1
   3
   0
 
 julia> hashfn(x -> x/(2π))
-3-element Array{Int32,1}:
+3-element Vector{Int32}:
  -1
  -2
  -1

--- a/docs/src/lshfunction_api.md
+++ b/docs/src/lshfunction_api.md
@@ -114,7 +114,7 @@ LSHFunctions.jl provides a few common utility functions that you can use across 
   julia> hashes = hashfn(rand(100));
 
   julia> typeof(hashes)
-  BitArray{1}
+  BitVector (alias for BitArray{1})
 
   julia> typeof(hashes[1]) == hashtype(hashfn)
   true

--- a/docs/src/similarities/cosine.md
+++ b/docs/src/similarities/cosine.md
@@ -76,7 +76,7 @@ julia> n_hashes(hashfn)
 julia> hashes = hashfn(randn(4));
 
 julia> typeof(hashes)
-BitArray{1}
+BitVector (alias for BitArray{1})
 
 julia> length(hashes)
 1

--- a/docs/src/similarities/jaccard.md
+++ b/docs/src/similarities/jaccard.md
@@ -40,12 +40,12 @@ UInt64
 julia> A = Set([1, 2, 3]);
 
 julia> hashfn(A)
-5-element Array{UInt64,1}:
- 0x21be0e591a3b69ea
- 0x19c5f638a776ab3c
- 0x63c12fd5d2f073ab
- 0x5c6b11e538a36352
- 0x129ef927e80a1b39
+5-element Vector{UInt64}:
+ 0x68ab426365cf3fcf
+ 0x13095267e4625e58
+ 0x0c0f74c97d4d341e
+ 0x1b294d39ad1e06a7
+ 0x74a5bce47c6b635a
 ```
 
 The probability of a collision for an individual hash between sets ``A`` and ``B`` is just equal to their Jaccard similarity, i.e.

--- a/docs/src/similarities/lp_distance.md
+++ b/docs/src/similarities/lp_distance.md
@@ -75,7 +75,7 @@ julia> x = rand(20);
 julia> hashes = hashfn(x);
 
 julia> typeof(hashes)
-Array{Int32,1}
+Vector{Int32} (alias for Array{Int32, 1})
 ```
 
 `L1Hash` and `L2Hash` support a keyword parameter called `scale`. `scale` impacts the collision probability: if `scale` is large then hash collisions are more likely (even among distant points). If `scale` is small, then hash collisions are less likely (even among close points).

--- a/src/function_hashing/monte_carlo.jl
+++ b/src/function_hashing/monte_carlo.jl
@@ -123,13 +123,13 @@ julia> μ() = 2π * rand(); # μ samples a random point from [0,2π]
 julia> hashfn = MonteCarloHash(L2, μ, 3; volume=2π);
 
 julia> hashfn(cos)
-3-element Array{Int32,1}:
+3-element Vector{Int32}:
  -1
   3
   0
 
 julia> hashfn(x -> x/(2π))
-3-element Array{Int32,1}:
+3-element Vector{Int32}:
  -1
  -2
  -1


### PR DESCRIPTION
This PR changes the GitHub Actions configuration so that we're only running unit tests on Ubuntu for the latest (non-nightly) version of Julia, and only on (a) pushes to master or (b) pull requests. This should make the CI pipeline less error-prone, but should also guarantee we don't run afoul of GitHub Actions' usage limits.

This PR also fixes some of the doctests that were broken by Julia 1.6.